### PR TITLE
feat: add statement_timeout option, BasePgStoreModule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hirosystems/api-toolkit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hirosystems/api-toolkit",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache 2.0",
       "dependencies": {
         "node-pg-migrate": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirosystems/api-toolkit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "API development toolkit",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,7 @@
+export const isDevEnv = process.env.NODE_ENV === 'development';
+export const isTestEnv = process.env.NODE_ENV === 'test';
+export const isProdEnv =
+  process.env.NODE_ENV === 'production' ||
+  process.env.NODE_ENV === 'prod' ||
+  !process.env.NODE_ENV ||
+  (!isTestEnv && !isDevEnv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './helpers';
 export * from './logger';
 export * from './postgres';
 export * from './server-version';

--- a/src/postgres/base-pg-store.ts
+++ b/src/postgres/base-pg-store.ts
@@ -79,7 +79,7 @@ export class BasePgStore {
    * Refreshes a materialized view concurrently depending on the current environment.
    * @param viewName - Materialized view name
    */
-  async refreshMaterializedView(viewName: string) {
+  async refreshMaterializedView(viewName: string): Promise<void> {
     await this.sql`REFRESH MATERIALIZED VIEW ${
       isProdEnv ? this.sql`CONCURRENTLY` : this.sql``
     } ${this.sql(viewName)}`;
@@ -99,7 +99,8 @@ export class BasePgStoreModule {
   protected get sql(): PgSqlClient {
     return this.parent.sql;
   }
-  protected async sqlTransaction<T>(
+
+  async sqlTransaction<T>(
     callback: (sql: PgSqlClient) => T | Promise<T>,
     readOnly = true
   ): Promise<UnwrapPromiseArray<T>> {
@@ -109,5 +110,8 @@ export class BasePgStoreModule {
     callback: (sql: PgSqlClient) => T | Promise<T>
   ): Promise<UnwrapPromiseArray<T>> {
     return this.sqlTransaction(callback, false);
+  }
+  async refreshMaterializedView(viewName: string): Promise<void> {
+    return this.parent.refreshMaterializedView(viewName);
   }
 }

--- a/src/postgres/connection.ts
+++ b/src/postgres/connection.ts
@@ -15,7 +15,7 @@ export type PgConnectionVars = {
   user?: string;
   password?: string;
   host?: string;
-  port?: string;
+  port?: number;
   schema?: string;
   ssl?: boolean;
   application_name?: string;
@@ -25,6 +25,7 @@ export type PgConnectionArgs = PgConnectionUri | PgConnectionVars;
 /** Postgres connection options */
 export type PgConnectionOptions = {
   idleTimeout?: number;
+  statementTimeout?: number;
   maxLifetime?: number;
   poolMax?: number;
 };
@@ -49,7 +50,7 @@ export function standardizedConnectionArgs(
       user: process.env.PGUSER,
       password: process.env.PGPASSWORD,
       host: process.env.PGHOST,
-      port: process.env.PGPORT ?? '5432',
+      port: parseInt(process.env.PGPORT ?? '5432'),
       ssl: true,
       application_name: `${appName}:${appUsage}`,
     };
@@ -150,7 +151,7 @@ export function getPostgres({
       user: args.user,
       password: args.password,
       host: args.host,
-      port: args.port ? parseInt(args.port) : undefined,
+      port: args.port,
       ssl: args.ssl,
       idle_timeout: connectionConfig?.idleTimeout,
       max_lifetime: connectionConfig?.maxLifetime,
@@ -159,6 +160,7 @@ export function getPostgres({
       connection: {
         application_name: args.application_name,
         search_path: args.schema,
+        statement_timeout: connectionConfig?.statementTimeout?.toString(),
       },
     });
   }

--- a/src/postgres/connection.ts
+++ b/src/postgres/connection.ts
@@ -24,9 +24,13 @@ export type PgConnectionVars = {
 export type PgConnectionArgs = PgConnectionUri | PgConnectionVars;
 /** Postgres connection options */
 export type PgConnectionOptions = {
+  /** Time to wait before automatically closing an idle connection (s) */
   idleTimeout?: number;
+  /** Maximum allowed duration of any statement (ms) */
   statementTimeout?: number;
+  /** Maximum time a connection can exist (s) */
   maxLifetime?: number;
+  /** Max number of connections */
   poolMax?: number;
 };
 

--- a/src/postgres/migrations.ts
+++ b/src/postgres/migrations.ts
@@ -25,7 +25,7 @@ export async function runMigrations(
         ? args
         : {
             host: args.host,
-            port: args.port ? parseInt(args.port) : undefined,
+            port: args.port,
             user: args.user,
             password: args.password,
             database: args.database,


### PR DESCRIPTION
* Add `statement_timeout` connection option for apps
* Create `BasePgStoreModule` so apps can separate queries into files
* Move `refreshMaterializedView` to `BasePgStore` and other helpers for reusability