### PR TITLE
fix: heap snapshot file download

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please see each tool's source directory for additional documentation
 * Node.js signal handlers that provide a way to shut down long-running application components
 gracefully on unhandled exceptions or interrupt signals.
 
-### CPU Profiler
+### Profiler server
 
 * Fastify server that controls a profiler capable of generating:
     * `.cpuprofile` files for CPU usage analysis

--- a/src/profiler/server.ts
+++ b/src/profiler/server.ts
@@ -155,13 +155,13 @@ const CpuProfiler: FastifyPluginCallback<Record<never, never>, Server, TypeBoxTy
       logger.info(
         `[HeapProfiler] Completed, total snapshot byte size: ${result.totalSnapshotByteSize}`
       );
+      await pipeline(fs.createReadStream(tmpFile), res.raw);
       await res.headers({
         'Cache-Control': 'no-store',
         'Transfer-Encoding': 'chunked',
         'Content-Disposition': `attachment; filename="${filename}"`,
         'Content-Type': 'application/json; charset=utf-8',
       });
-      await pipeline(fs.createReadStream(tmpFile), res.raw);
     } finally {
       const session = existingSession;
       existingSession = undefined;


### PR DESCRIPTION
Hotfix to solve a heap snapshot file download problem where the response was never sent back to the client with the file