### PR TITLE
fix: isFinished never set on `waiter()`

### DIFF
--- a/src/helpers/__tests__/helpers.test.ts
+++ b/src/helpers/__tests__/helpers.test.ts
@@ -1,5 +1,5 @@
 import * as events from 'node:events';
-import { timeout } from '../time';
+import { timeout, waiter } from '../time';
 
 describe('Helper tests', () => {
   test('timeout function should not cause memory leak by accumulating abort listeners on abort', async () => {
@@ -48,5 +48,12 @@ describe('Helper tests', () => {
 
     // Final check to confirm listeners are cleaned up
     expect(countListeners()).toBe(0);
+  });
+
+  test('waiter is finished', async () => {
+    const myWaiter = waiter();
+    myWaiter.finish();
+    await myWaiter;
+    expect(myWaiter.isFinished).toBe(true);
   });
 });

--- a/src/helpers/time.ts
+++ b/src/helpers/time.ts
@@ -121,7 +121,7 @@ export function waiter<T = void>(): Waiter<T> {
   });
   const completer = {
     finish: (result: T) => {
-      completer.isFinished = true;
+      void Object.assign(promise, { isFinished: true });
       resolveFn(result);
     },
     isFinished: false,


### PR DESCRIPTION
The `isFinished` property wasn't being updated on the promise object returned from the `waiter()` function.