### PR TITLE
fix: pg connection error detection

### DIFF
--- a/src/postgres/errors.ts
+++ b/src/postgres/errors.ts
@@ -41,6 +41,8 @@ export function isPgConnectionError(error: any): string | false {
       return 'Postgres connection closed due to administrator command';
     } else if (msg.includes('password authentication failed')) {
       return 'Postgres authentication failed';
+    } else if (msg.includes('database system is not yet accepting connections')) {
+      return 'Postgres not yet accepting connections';
     }
   }
   return false;


### PR DESCRIPTION
The `isPgConnectionError` function was missing a check for `PostgresError: the database system is not yet accepting connections`

