### PR TITLE
fix: git info check should not throw when debugging

### DIFF
--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './iterators';
 export * from './time';
 export * from './values';
+export * from './is-debugging';

--- a/src/helpers/is-debugging.ts
+++ b/src/helpers/is-debugging.ts
@@ -1,0 +1,12 @@
+/*
+ * Reliable way to check if we are debugging. Supports ts-node and other tools unlike some other
+ * approaches that check argv or env vars. It also lazy-loads the `node:inspector` module to avoid
+ * unnecessary overhead in production environments where this function might not be called.
+ */
+export function isDebugging() {
+  type NodeInspectorType = typeof import('node:inspector');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const inspector = require('node:inspector') as NodeInspectorType;
+  const url = inspector.url();
+  return url !== undefined;
+}

--- a/src/server-version/__tests__/server-version.test.ts
+++ b/src/server-version/__tests__/server-version.test.ts
@@ -2,9 +2,35 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { spawnSync, execSync } from 'child_process';
+import { getServerVersion } from '../index';
+import { isDebugging } from '../../helpers';
 
 const scriptFilePath = path.resolve('bin/api-toolkit-git-info.js');
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), '.tmp'));
+
+describe('getServerVersion does not throw when debugging', () => {
+  let debuggingEnabled: boolean;
+  let originalEnv: string | undefined;
+
+  beforeAll(() => {
+    debuggingEnabled = isDebugging();
+    originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'prod';
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  test('getServerVersion does not throw when debugging', () => {
+    if (!debuggingEnabled) {
+      console.log(`Skipping test because debugging is not enabled.`);
+      return;
+    }
+    const version = getServerVersion();
+    expect(version.branch).toBe('debugging');
+  });
+});
 
 describe('git info script', () => {
   test('error when git repo data not available', () => {


### PR DESCRIPTION
The git-info script throws unwanted errors in certain debugging scenarios. It previously had an env var check for `NODE_ENV=test` to avoid throwing in the context of tests, but this is often not set when debugging in other situations.

This PR keeps that condition, and adds a new condition:
* If the `.git-info` file does not exist, and a debugger is not attached, then do not throw.

This is implemented with a lazy-loaded function call and module-load _after_ the `.git-info` file-not-found error:
```ts
const isDebugging = () => require('node:inspector').url() !== undefined';
```

This PR also exposes this `isDebugging` helper function because that code is often useful in other projects that use this library. 