### PR TITLE
feat: support sql transactions for multiple databases

### DIFF
--- a/src/helpers/values.ts
+++ b/src/helpers/values.ts
@@ -142,3 +142,19 @@ export function toEnumValue<T>(enm: { [s: string]: T }, value: string): T | unde
     ? (value as unknown as T)
     : undefined;
 }
+
+/**
+ * Unwraps a value that may be undefined or null.
+ * @param val - The value to unwrap
+ * @param onNullish - Callback to throw an error if the value is null or undefined
+ * @returns The unwrapped value
+ */
+export function unwrap<T>(val: T | null, onNullish?: () => string): Exclude<T, undefined | null> {
+  if (val === undefined) {
+    throw new Error(onNullish?.() ?? 'value is undefined');
+  }
+  if (val === null) {
+    throw new Error(onNullish?.() ?? 'value is null');
+  }
+  return val as Exclude<T, undefined | null>;
+}

--- a/src/postgres/__tests__/base-pg-store.test.ts
+++ b/src/postgres/__tests__/base-pg-store.test.ts
@@ -92,21 +92,18 @@ describe('BasePgStore', () => {
   });
 
   test('postgres transaction connection integrity', async () => {
-    const usageName = 'postgres:test;datastore-crud';
     const obj = db.sql;
+    const dbName = obj.options.database;
 
     expect(sqlTransactionContext.getStore()).toBeUndefined();
     await db.sqlTransaction(async sql => {
-      // Transaction flag is open.
-      expect(sqlTransactionContext.getStore()?.usageName).toBe(usageName);
       // New connection object.
       const newObj = sql;
       expect(obj).not.toEqual(newObj);
-      expect(sqlTransactionContext.getStore()?.sql).toEqual(newObj);
+      expect(sqlTransactionContext.getStore()?.[dbName]).toEqual(newObj);
 
       // Nested tx uses the same connection object.
       await db.sqlTransaction(sql => {
-        expect(sqlTransactionContext.getStore()?.usageName).toBe(usageName);
         expect(newObj).toEqual(sql);
       });
 


### PR DESCRIPTION
Modifies the `AsyncLocalStorage` to support one `PgSqlClient` per database instead of only one globally. Allows clients to connect to multiple DBs simultaneously with independent SQL transaction contexts.

Also adds an unwrap helper function, migrated from the Stacks API repo.