### PR TITLE
fix: ignore .d.ts files from migrations

### DIFF
--- a/src/postgres/migrations.ts
+++ b/src/postgres/migrations.ts
@@ -39,7 +39,7 @@ export async function runMigrations(
     dir,
     direction,
     count: Infinity,
-    ignorePattern: '.*map',
+    ignorePattern: '.*(\\.map|\\.d\\.ts)',
     databaseUrl:
       typeof args === 'string'
         ? args


### PR DESCRIPTION
Allows running migrations compiled from TS monorepos